### PR TITLE
added failing test for nonexistent array key cannot be tainted

### DIFF
--- a/tests/019.phpt
+++ b/tests/019.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Non existent array key cannot be tainted
+--SKIPIF--
+<?php if (!extension_loaded("taint")) print "skip"; ?>
+--INI--
+taint.enable=1
+--FILE--
+$a = array();
+taint($a['noneExistent']);
+var_dump(is_tainted($a['noneExistent']));
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
I expected this case to work like demonstrated in the test.